### PR TITLE
update Oracle repository signing key

### DIFF
--- a/src/jepsen/mysql/db/mysql.clj
+++ b/src/jepsen/mysql/db/mysql.clj
@@ -25,6 +25,7 @@
   "Installs MySQL"
   [test node]
   (c/su
+    (debian/install [:lsb-release]) ; pre-dependancy
     (c/cd "/tmp"
           ; See https://dev.mysql.com/downloads/repo/apt/
           (let [deb (cu/wget! "https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb")]

--- a/src/jepsen/mysql/db/mysql.clj
+++ b/src/jepsen/mysql/db/mysql.clj
@@ -27,7 +27,7 @@
   (c/su
     (c/cd "/tmp"
           ; See https://dev.mysql.com/downloads/repo/apt/
-          (let [deb (cu/wget! "https://dev.mysql.com/get/mysql-apt-config_0.8.26-1_all.deb")]
+          (let [deb (cu/wget! "https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb")]
             (c/exec "DEBIAN_FRONTEND=noninteractive" :dpkg :-i deb)))
     (c/exec :apt :update)
     (debian/install [:mysql-server :mysql-client])))


### PR DESCRIPTION
Oracle updated their repository signing keys on 12/14: https://bugs.mysql.com/bug.php?id=113427

Update `mysql-apt-config` to version that includes new keys. 