### PR TITLE
Merge upstream/main, modernize Docker, add CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Install Leiningen
+        uses: DeLaGuardo/setup-clojure@13.6.0
+        with:
+          lein: latest
+
+      - name: Cache Leiningen dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-lein-${{ hashFiles('project.clj') }}
+          restore-keys: ${{ runner.os }}-lein-
+
+      - name: Compile check
+        run: lein check
+
+  deploy:
+    needs: check
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Install Leiningen
+        uses: DeLaGuardo/setup-clojure@13.6.0
+        with:
+          lein: latest
+
+      - name: Cache Leiningen dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-lein-${{ hashFiles('project.clj') }}
+          restore-keys: ${{ runner.os }}-lein-
+
+      - name: Parse version
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=defproject jepsen\.mariadb ")[^"]+' project.clj)
+
+          COMMIT_MSG=$(git log -1 --format=%s)
+
+          if [[ "$COMMIT_MSG" =~ \[release\ ([0-9]+\.[0-9]+\.[0-9]+)\] ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+          elif [[ "$COMMIT_MSG" =~ \[release\] ]]; then
+            VERSION="${VERSION%-SNAPSHOT}"
+          else
+            BASE="${VERSION%-SNAPSHOT}"
+            TS=$(date -u +%Y%m%d%H%M%S)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            VERSION="${BASE}-${TS}-${SHORT_SHA}"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set deploy version
+        run: |
+          sed -i "s/defproject jepsen\.mariadb \"[^\"]*\"/defproject jepsen.mariadb \"${{ steps.version.outputs.version }}\"/" project.clj
+
+      - name: Deploy to GitHub Packages
+        env:
+          DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO_URL="https://maven.pkg.github.com/${{ github.repository }}"
+          mkdir -p ~/.lein
+          cat > ~/.lein/profiles.clj <<EOF
+          {:github-deploy
+           {:deploy-repositories
+            [["github" {:url "${REPO_URL}"
+                        :username "${{ github.actor }}"
+                        :password "${DEPLOY_TOKEN}"
+                        :sign-releases false}]]}}
+          EOF
+          lein with-profile +github-deploy deploy github

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,158 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/mariadb-jepsen
+  IMAGE_ARTIFACT: /tmp/mariadb-jepsen.tar.zst
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      is_release: ${{ steps.version.outputs.is_release }}
+      release_version: ${{ steps.version.outputs.release_version }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Parse version from project.clj
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=defproject jepsen\.mariadb ")[^"]+' project.clj)
+
+          COMMIT_MSG=$(git log -1 --format=%s)
+          IS_RELEASE=false
+          RELEASE_VERSION=""
+
+          if [[ "$COMMIT_MSG" =~ \[release\ ([0-9]+\.[0-9]+\.[0-9]+)\] ]]; then
+            IS_RELEASE=true
+            RELEASE_VERSION="${BASH_REMATCH[1]}"
+          elif [[ "$COMMIT_MSG" =~ \[release\] ]]; then
+            IS_RELEASE=true
+            RELEASE_VERSION="${VERSION%-SNAPSHOT}"
+          fi
+
+          echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "$IS_RELEASE" = "true" ]; then
+            TAG="$RELEASE_VERSION"
+          else
+            BASE="${VERSION%-SNAPSHOT}"
+            TS=$(date -u +%Y%m%d%H%M%S)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            TAG="${BASE}-${TS}-${SHORT_SHA}"
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: mariadb-docker/Dockerfile
+          load: true
+          tags: mariadb-jepsen:${{ steps.version.outputs.tag }}
+
+      - name: Save image
+        run: docker save mariadb-jepsen:${{ steps.version.outputs.tag }} | zstd -T0 -o $IMAGE_ARTIFACT
+
+      - name: Upload image
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ env.IMAGE_ARTIFACT }}
+          archive: false
+          retention-days: 1
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download image
+        uses: actions/download-artifact@v8
+        with:
+          name: mariadb-jepsen.tar.zst
+          path: /tmp
+
+      - name: Load image
+        run: zstd -d $IMAGE_ARTIFACT --stdout | docker load
+
+      - name: Integration test
+        run: |
+          docker run -e TEST_SCRIPT=/verify.sh \
+            mariadb-jepsen:${{ needs.build.outputs.tag }} \
+            https://github.com/MariaDB/server 10.11
+        timeout-minutes: 180
+
+  publish:
+    needs: [build, test]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download image
+        uses: actions/download-artifact@v8
+        with:
+          name: mariadb-jepsen.tar.zst
+          path: /tmp
+
+      - name: Load image
+        run: zstd -d $IMAGE_ARTIFACT --stdout | docker load
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and push
+        run: |
+          docker tag mariadb-jepsen:${{ needs.build.outputs.tag }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.tag }}
+          docker tag mariadb-jepsen:${{ needs.build.outputs.tag }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.tag }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Release version bump
+        if: needs.build.outputs.is_release == 'true'
+        run: |
+          set -e
+          RELEASE_VERSION="${{ needs.build.outputs.release_version }}"
+
+          IFS='.' read -r MAJOR MINOR MICRO <<< "$RELEASE_VERSION"
+          if ! [[ "$MICRO" =~ ^[0-9]+$ ]]; then
+            echo "Error: invalid micro version '$MICRO' in $RELEASE_VERSION" >&2
+            exit 1
+          fi
+
+          sed -i "s/defproject jepsen\.mariadb \"[^\"]*\"/defproject jepsen.mariadb \"${RELEASE_VERSION}\"/" project.clj
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git add project.clj
+          git commit -m "Release ${RELEASE_VERSION} [skip ci]"
+          git tag "v${RELEASE_VERSION}"
+
+          NEXT_MICRO=$((MICRO + 1))
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_MICRO}-SNAPSHOT"
+          sed -i "s/defproject jepsen\.mariadb \"[^\"]*\"/defproject jepsen.mariadb \"${NEXT_VERSION}\"/" project.clj
+          git add project.clj
+          git commit -m "Version ${NEXT_VERSION} [skip ci]"
+
+          git push origin HEAD:main --tags

--- a/mariadb-docker/Dockerfile
+++ b/mariadb-docker/Dockerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1
+
+# The image is for testing MariaDB isolation violations with Jepsen
+#
+# Usage: docker run ubuntu-22.04/jepsen:v1 mariadb_branch_name
+#
+# Build me with the following command:
+# PROGRESS_NO_TRUNC=1 DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain BUILDKIT_STEP_LOG_MAX_SIZE=1024000000 BUILDKIT_STEP_LOG_MAX_SPEED=1024000000 docker build --progress plain -t ubuntu-22.04/jepsen:v1 .
+#
+FROM ubuntu:22.04
+RUN <<EOT
+cp /etc/apt/sources.list /etc/apt/sources.list~
+sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+apt update
+apt -y upgrade
+apt -y install dpkg-dev
+apt -y install git cmake gcc g++ vim libncurses-dev gnutls-dev bison make automake libtool pkg-config libaio-dev libpcre2-dev zlib1g-dev default-jre default-jdk wget
+# The following is neccessaery to run lein
+apt -y install sudo git openjdk-21-jre openjdk-21-jdk openssh-server openssh-client wget
+# The following is neccessary fo Jepsen, I am not sure the all packages are neccessary, it's just copied from jepsen/src/jepsen/os/debian.clj
+apt -y install apt-transport-https libzip4 curl man-db faketime netcat-openbsd ntpdate unzip iptables psmisc tar bzip2 iputils-ping iproute2 rsyslog logrotate dirmngr tcpdump
+apt -y install graphviz gnuplot
+EOT
+
+RUN adduser --disabled-password -gecos "" mariadb
+
+USER mariadb
+
+RUN <<EOT
+# SSH is not neccessary for single-machine tests, but Jepsen itself can
+# require it for some cases, so just leave it here just in case.
+#ssh-keygen -b 2048 -t rsa -f ~/.ssh/localhost -q -N ""
+
+cd ~
+git clone https://github.com/vlad-lesin/jepsen-mysql
+wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+EOT
+
+USER root
+RUN chmod a+x /home/mariadb/lein
+
+USER mariadb
+RUN <<EOT
+cd ~/jepsen-mysql
+# Download all neccessary for the project
+../lein run test --help
+EOT
+
+USER root
+# SSH is not neccessary for single-machine tests, but Jepsen itself can
+# require it for some cases, so just leave it here just in case.
+#RUN <<EOT
+#bash -c 'echo -e "root\nroot\n" | passwd root'
+#sed -i 's,^#\?PermitRootLogin .*,PermitRootLogin yes,g' /etc/ssh/sshd_config
+#mkdir -p ~/.ssh
+#chmod 700 ~/.ssh
+#cp /home/mariadb/.ssh/localhost.pub ~/.ssh/authorized_keys
+#chmod 644 ~/.ssh/authorized_keys
+#echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+#adduser mariadb sudo
+#EOT
+COPY ./start.sh /
+
+USER mariadb
+RUN <<EOT
+# SSH is not neccessary for single-machine tests, but Jepsen itself can
+# require it for some cases, so just leave it here just in case.
+
+#sudo service ssh start
+#ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
+#mkdir -p ~/mariadb-bin/data
+mkdir -p ~/mariadb-bin/tmp
+EOT
+
+ENTRYPOINT ["/start.sh"]

--- a/mariadb-docker/Dockerfile
+++ b/mariadb-docker/Dockerfile
@@ -2,74 +2,50 @@
 
 # The image is for testing MariaDB isolation violations with Jepsen
 #
-# Usage: docker run ubuntu-22.04/jepsen:v1 mariadb_branch_name
+# Build (from the repo root):
+#   docker build -t mariadb-jepsen -f mariadb-docker/Dockerfile .
 #
-# Build me with the following command:
-# PROGRESS_NO_TRUNC=1 DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain BUILDKIT_STEP_LOG_MAX_SIZE=1024000000 BUILDKIT_STEP_LOG_MAX_SPEED=1024000000 docker build --progress plain -t ubuntu-22.04/jepsen:v1 .
+# Run (clone & build MariaDB, then test):
+#   docker run mariadb-jepsen https://github.com/MariaDB/server 11.8
 #
-FROM ubuntu:22.04
+# Run (prebuilt install mounted from host):
+#   docker run -v /path/to/install:/home/mariadb/mariadb-bin mariadb-jepsen
+#
+# Run (build tree mounted from host):
+#   docker run -v /path/to/build-tree:/home/mariadb/mariadb-bin mariadb-jepsen
+#
+FROM ubuntu:24.04
+
 RUN <<EOT
-cp /etc/apt/sources.list /etc/apt/sources.list~
-sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
-apt update
-apt -y upgrade
-apt -y install dpkg-dev
-apt -y install git cmake gcc g++ vim libncurses-dev gnutls-dev bison make automake libtool pkg-config libaio-dev libpcre2-dev zlib1g-dev default-jre default-jdk wget
-# The following is neccessaery to run lein
-apt -y install sudo git openjdk-21-jre openjdk-21-jdk openssh-server openssh-client wget
-# The following is neccessary fo Jepsen, I am not sure the all packages are neccessary, it's just copied from jepsen/src/jepsen/os/debian.clj
-apt -y install apt-transport-https libzip4 curl man-db faketime netcat-openbsd ntpdate unzip iptables psmisc tar bzip2 iputils-ping iproute2 rsyslog logrotate dirmngr tcpdump
-apt -y install graphviz gnuplot
+set -e
+sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+apt-get update
+apt-get -y upgrade
+# SSH is not used for single-machine tests but Jepsen may require it for
+# multi-node setups, so the packages are installed but not configured.
+apt-get -y install --no-install-recommends \
+    dpkg-dev git cmake gcc g++ vim libncurses-dev gnutls-dev bison make \
+    automake libtool pkg-config libaio-dev libpcre2-dev zlib1g-dev \
+    sudo openjdk-21-jre openjdk-21-jdk wget \
+    openssh-server openssh-client \
+    apt-transport-https libzip4t64 curl man-db faketime netcat-openbsd \
+    ntpsec-ntpdate unzip iptables psmisc tar bzip2 iputils-ping iproute2 \
+    rsyslog logrotate dirmngr tcpdump graphviz gnuplot
+apt-get clean
+rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/log/apt/* /var/log/dpkg.log
+adduser --disabled-password --comment "" mariadb
+wget -O /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+chmod a+x /usr/local/bin/lein
 EOT
 
-RUN adduser --disabled-password -gecos "" mariadb
+COPY mariadb-docker/start.sh mariadb-docker/tests.sh mariadb-docker/verify.sh /
 
 USER mariadb
 
-RUN <<EOT
-# SSH is not neccessary for single-machine tests, but Jepsen itself can
-# require it for some cases, so just leave it here just in case.
-#ssh-keygen -b 2048 -t rsa -f ~/.ssh/localhost -q -N ""
+COPY --chown=mariadb:mariadb project.clj /home/mariadb/jepsen-mariadb/
+RUN cd ~/jepsen-mariadb && lein deps
 
-cd ~
-git clone https://github.com/vlad-lesin/jepsen-mysql
-wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
-EOT
-
-USER root
-RUN chmod a+x /home/mariadb/lein
-
-USER mariadb
-RUN <<EOT
-cd ~/jepsen-mysql
-# Download all neccessary for the project
-../lein run test --help
-EOT
-
-USER root
-# SSH is not neccessary for single-machine tests, but Jepsen itself can
-# require it for some cases, so just leave it here just in case.
-#RUN <<EOT
-#bash -c 'echo -e "root\nroot\n" | passwd root'
-#sed -i 's,^#\?PermitRootLogin .*,PermitRootLogin yes,g' /etc/ssh/sshd_config
-#mkdir -p ~/.ssh
-#chmod 700 ~/.ssh
-#cp /home/mariadb/.ssh/localhost.pub ~/.ssh/authorized_keys
-#chmod 644 ~/.ssh/authorized_keys
-#echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-#adduser mariadb sudo
-#EOT
-COPY ./start.sh /
-
-USER mariadb
-RUN <<EOT
-# SSH is not neccessary for single-machine tests, but Jepsen itself can
-# require it for some cases, so just leave it here just in case.
-
-#sudo service ssh start
-#ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
-#mkdir -p ~/mariadb-bin/data
-mkdir -p ~/mariadb-bin/tmp
-EOT
+COPY --chown=mariadb:mariadb . /home/mariadb/jepsen-mariadb
+RUN cd ~/jepsen-mariadb && lein check
 
 ENTRYPOINT ["/start.sh"]

--- a/mariadb-docker/README.md
+++ b/mariadb-docker/README.md
@@ -1,0 +1,75 @@
+# MariaDB Jepsen Docker
+
+Docker image for testing MariaDB transaction isolation with Jepsen.
+
+## Building the Image
+
+From the repository root:
+
+```bash
+docker build -t mariadb-jepsen -f mariadb-docker/Dockerfile .
+```
+
+## Running Tests
+
+The entrypoint supports three modes, auto-detected based on arguments and
+the contents of the mount point.
+
+### Clone & Build Mode
+
+Pass a MariaDB server git repository URL and an optional committish
+(branch, tag, or SHA) to clone, build from source, and run all tests:
+
+```bash
+docker run mariadb-jepsen https://github.com/MariaDB/server 11.8
+```
+
+The committish is optional. If omitted, the repository's default branch is used:
+
+```bash
+docker run mariadb-jepsen https://github.com/MariaDB/server
+```
+
+### Prebuilt Install Mode
+
+Mount a directory containing an installed MariaDB (standard prefix layout
+with `bin/`, `scripts/`, `lib/plugin/`) and run with no arguments:
+
+```bash
+docker run -v /path/to/install:/home/mariadb/mariadb-bin mariadb-jepsen
+```
+
+### Build Tree Mode
+
+Mount a cmake build tree directly (with `sql/mariadbd`, `client/mysqladmin`,
+etc.) and run with no arguments. The entrypoint detects the build tree layout
+and creates a symlink shim automatically:
+
+```bash
+docker run -v /path/to/build-tree:/home/mariadb/mariadb-bin mariadb-jepsen
+```
+
+## Test Scripts
+
+After MariaDB setup, the entrypoint executes a test script controlled by the
+`TEST_SCRIPT` environment variable. The default is `/tests.sh`.
+
+### Full Suite (`/tests.sh`, default)
+
+Runs the following workloads at multiple isolation levels:
+
+- **append** at serializable, repeatable-read, read-committed, read-uncommitted
+- **nonrepeatable-read** at serializable, repeatable-read
+- **mav** at serializable, repeatable-read
+
+### Verification (`/verify.sh`)
+
+Runs a single short append test at serializable to validate that both MariaDB
+and Jepsen are functional:
+
+```bash
+docker run -e TEST_SCRIPT=/verify.sh mariadb-jepsen https://github.com/MariaDB/server 11.8
+```
+
+All tests use `--innodb-snapshot-isolation` and run against a single local
+MariaDB instance (no SSH, no nemesis).

--- a/mariadb-docker/start.sh
+++ b/mariadb-docker/start.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+BRANCH=$1
+NPROC=`nproc --all`
+PREFIX=~/mariadb-bin
+
+LEIN_OPTIONS="run test --db maria-docker --nodes localhost --concurrency ${NPROC} --rate 1000 --time-limit 60 --key-count 40 --no-ssh=true --innodb-strict-isolation=true"
+
+cd ~
+# Update the test
+rm -rf jepsen-mysql
+git clone https://github.com/vlad-lesin/jepsen-mysql
+git clone https://github.com/MariaDB/server --branch $BRANCH --depth 1
+
+mkdir build
+cd build
+cmake ../server -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER,SPHINX,COLUMNSTORE,PERFSCHEMA,XPAND}=NO -DWITH_SAFEMALLOC=OFF -DCMAKE_BUILD_TYPE=RelWithDebinfo -DCMAKE_INSTALL_PREFIX=$PREFIX && make -j$NPROC install
+
+# SSH is not neccessary for single-machine tests, but Jepsen itself can
+# require it for some cases, so just leave it here just in case.
+# sudo service ssh start
+
+cd ../jepsen-mysql
+echo "===========Append serializable============="
+../lein $LEIN_OPTIONS -w append -i serializable
+echo "===========Append repeatable-read============="
+../lein $LEIN_OPTIONS -w append -i repeatable-read
+echo "===========Append read-committed============="
+../lein $LEIN_OPTIONS -w append -i read-committed
+echo "===========Append read-uncommitted============="
+../lein $LEIN_OPTIONS -w append -i read-uncommitted
+
+echo "===========Non-repeatable read serializable============="
+../lein $LEIN_OPTIONS -w nonrepeatable-read -i serializable
+echo "===========Non-repeatable repeatable-read============="
+../lein $LEIN_OPTIONS -w nonrepeatable-read -i repeatable-read
+
+echo "===========mav serializable============="
+../lein $LEIN_OPTIONS -w mav -i serializable
+echo "===========mav repeatable-read============="
+../lein $LEIN_OPTIONS -w mav -i repeatable-read
+

--- a/mariadb-docker/start.sh
+++ b/mariadb-docker/start.sh
@@ -1,42 +1,55 @@
 #!/bin/bash
+set -euo pipefail
 
-BRANCH=$1
-NPROC=`nproc --all`
-PREFIX=~/mariadb-bin
+NPROC=$(nproc --all)
+MARIADB_DIR=~/mariadb-bin
 
-LEIN_OPTIONS="run test --db maria-docker --nodes localhost --concurrency ${NPROC} --rate 1000 --time-limit 60 --key-count 40 --no-ssh=true --innodb-strict-isolation=true"
+create_build_tree_shim() {
+    local src=$1
+    local shim=~/mariadb-shim
+    mkdir -p "$shim/bin" "$shim/scripts" "$shim/lib/plugin"
+    ln -sf "$src/sql/mariadbd" "$shim/bin/mariadbd"
+    ln -sf "$src/scripts/mariadbd-safe" "$shim/bin/mariadbd-safe"
+    ln -sf "$src/client/mysqladmin" "$shim/bin/mysqladmin"
+    ln -sf "$src/scripts/mariadb-install-db" "$shim/scripts/mariadb-install-db"
+    find "$src/plugin" "$src/storage" -maxdepth 2 -name '*.so' -type f \
+        -exec ln -sf {} "$shim/lib/plugin/" \;
+    MARIADB_DIR=$shim
+}
 
-cd ~
-# Update the test
-rm -rf jepsen-mysql
-git clone https://github.com/vlad-lesin/jepsen-mysql
-git clone https://github.com/MariaDB/server --branch $BRANCH --depth 1
+if [ $# -gt 0 ]; then
+    REPO=$1
+    COMMITTISH=${2:-}
 
-mkdir build
-cd build
-cmake ../server -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER,SPHINX,COLUMNSTORE,PERFSCHEMA,XPAND}=NO -DWITH_SAFEMALLOC=OFF -DCMAKE_BUILD_TYPE=RelWithDebinfo -DCMAKE_INSTALL_PREFIX=$PREFIX && make -j$NPROC install
+    cd ~
+    if [ -n "$COMMITTISH" ]; then
+        git clone "$REPO" --branch "$COMMITTISH" --depth 1 server
+    else
+        git clone "$REPO" --depth 1 server
+    fi
 
-# SSH is not neccessary for single-machine tests, but Jepsen itself can
-# require it for some cases, so just leave it here just in case.
-# sudo service ssh start
+    cmake -S server -B build \
+        -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER,SPHINX,COLUMNSTORE,PERFSCHEMA,XPAND}=NO \
+        -DWITH_SAFEMALLOC=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebinfo \
+        -DCMAKE_INSTALL_PREFIX="$MARIADB_DIR"
+    cmake --build build -j"$NPROC"
+    cmake --install build
+    rm -rf ~/server ~/build
+elif [ -f "$MARIADB_DIR/sql/mariadbd" ]; then
+    create_build_tree_shim "$MARIADB_DIR"
+fi
 
-cd ../jepsen-mysql
-echo "===========Append serializable============="
-../lein $LEIN_OPTIONS -w append -i serializable
-echo "===========Append repeatable-read============="
-../lein $LEIN_OPTIONS -w append -i repeatable-read
-echo "===========Append read-committed============="
-../lein $LEIN_OPTIONS -w append -i read-committed
-echo "===========Append read-uncommitted============="
-../lein $LEIN_OPTIONS -w append -i read-uncommitted
+if [ ! -f "$MARIADB_DIR/bin/mariadbd" ]; then
+    echo "Error: mariadbd not found at $MARIADB_DIR/bin/mariadbd" >&2
+    echo "Usage:" >&2
+    echo "  Clone & build:    docker run mariadb-jepsen <repo-url> [committish]" >&2
+    echo "  Prebuilt install: docker run -v /path/to/install:/home/mariadb/mariadb-bin mariadb-jepsen" >&2
+    echo "  Build tree:       docker run -v /path/to/build-tree:/home/mariadb/mariadb-bin mariadb-jepsen" >&2
+    exit 1
+fi
 
-echo "===========Non-repeatable read serializable============="
-../lein $LEIN_OPTIONS -w nonrepeatable-read -i serializable
-echo "===========Non-repeatable repeatable-read============="
-../lein $LEIN_OPTIONS -w nonrepeatable-read -i repeatable-read
+export LEIN_OPTIONS="run test --db maria-docker --nodes localhost --concurrency ${NPROC} --rate 1000 --no-ssh=true --innodb-snapshot-isolation --mariadb-install-dir ${MARIADB_DIR}"
 
-echo "===========mav serializable============="
-../lein $LEIN_OPTIONS -w mav -i serializable
-echo "===========mav repeatable-read============="
-../lein $LEIN_OPTIONS -w mav -i repeatable-read
-
+cd ~/jepsen-mariadb
+exec "${TEST_SCRIPT:-/tests.sh}"

--- a/mariadb-docker/tests.sh
+++ b/mariadb-docker/tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "===========Append serializable============="
+lein $LEIN_OPTIONS --time-limit 60 --key-count 40 -w append -i serializable
+echo "===========Append repeatable-read============="
+lein $LEIN_OPTIONS --time-limit 60 --key-count 40 -w append -i repeatable-read
+echo "===========Append read-committed============="
+lein $LEIN_OPTIONS --time-limit 60 --key-count 40 -w append -i read-committed
+echo "===========Append read-uncommitted============="
+lein $LEIN_OPTIONS --time-limit 60 --key-count 40 -w append -i read-uncommitted
+
+echo "===========Non-repeatable read serializable============="
+lein $LEIN_OPTIONS --time-limit 60 --key-count 40 -w nonrepeatable-read -i serializable
+echo "===========Non-repeatable repeatable-read============="
+lein $LEIN_OPTIONS --time-limit 60 --key-count 40 -w nonrepeatable-read -i repeatable-read
+
+echo "===========mav serializable============="
+lein $LEIN_OPTIONS --time-limit 60 --key-count 40 -w mav -i serializable
+echo "===========mav repeatable-read============="
+lein $LEIN_OPTIONS --time-limit 60 --key-count 40 -w mav -i repeatable-read

--- a/mariadb-docker/verify.sh
+++ b/mariadb-docker/verify.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "===========Build smoke test============="
+lein $LEIN_OPTIONS --time-limit 10 -w build-smoke-test -i serializable

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen.mysql "0.0.3-SNAPSHOT"
+(defproject jepsen.mariadb "0.0.3-SNAPSHOT"
   :description "Jepsen tests for MySQL and MariaDB"
   :url "https://github.com/jepsen-io/mysql"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
@@ -15,9 +15,9 @@
                                com.fasterxml.jackson.core/jackson-core]]
                  [io.jepsen/antithesis "0.1.0"]
                  [http-kit "2.8.1"]
-                 [com.github.seancorfield/next.jdbc "1.3.1070"]
-                 [com.mysql/mysql-connector-j "9.5.0"]
-                 [org.mariadb.jdbc/mariadb-java-client "3.5.6"]]
+                 [com.github.seancorfield/next.jdbc "1.3.1093"]
+                 [com.mysql/mysql-connector-j "9.7.0"]
+                 [org.mariadb.jdbc/mariadb-java-client "3.5.8"]]
   :main jepsen.mysql.cli
   :repl-options {:init-ns jepsen.mysql.repl}
   :jvm-opts ["-Djava.awt.headless=true"

--- a/resources/maria-docker.cnf
+++ b/resources/maria-docker.cnf
@@ -6,6 +6,9 @@ max_connections = 4096
 default_authentication_plugin=mysql_native_password
 
 [mariadb]
+tmpdir = %TMPDIR%
+socket = %SOCKET%
+port = %PORT%
 pid_file=%PID_FILE%
 log_error=%ERROR_LOG%
 datadir=%DATA_DIR%

--- a/resources/maria-docker.cnf
+++ b/resources/maria-docker.cnf
@@ -1,0 +1,43 @@
+[mysqld]
+bind-address = %IP%
+max_connections = 4096
+# caching_sha2_password requires us to set up a whole CA and do cert exchange,
+# which is exhausting
+default_authentication_plugin=mysql_native_password
+
+[mariadb]
+pid_file=%PID_FILE%
+log_error=%ERROR_LOG%
+datadir=%DATA_DIR%
+general_log
+log-bin
+server_id = %SERVER_ID%
+log-basename = jepsen
+binlog-format = %BINLOG_FORMAT%
+#binlog-group-commit-sync-delay = 30
+# Per an email from Jean-François Gagné, using COMMIT_ORDER here might recover
+# safety even with replica-preserve-commit-order off.
+binlog-transaction-dependency-tracking = %BINLOG_TRANSACTION_DEPENDENCY_TRACKING%
+#log-statements-unsafe-for-binlog = OFF
+
+# This option lets you turn off ordered replication, in case you don't want
+# serializability to work for some reason
+replica-preserve-commit-order	= %REPLICA_PRESERVE_COMMIT_ORDER%
+
+# Make absolutely sure nobody writes to secondaries
+super_read_only = %SUPER_READ_ONLY%
+
+# so apparently crash safety is not the default and you have to turn on a
+# bunch of extra options?????? !???
+#enforce_gtid_consistency = ON
+#gtid_mode = ON
+#sync_relay_log = 1 # what on earth, why is this default so high if it's unsafe?
+#relay_log_recovery = ON # Also not the default for some reason? Why????
+
+# Not entirely sure whether/how this comes into play given deadlock detection,
+# but I can't think of a scenario where we want 50-second txn stalls
+innodb_lock_wait_timeout = 1
+
+# Intentionally lowerable for verifying lazyfs is working
+innodb_flush_log_at_trx_commit = %INNODB_FLUSH_LOG_AT_TRX_COMMIT%
+innodb_flush_log_at_timeout = 60

--- a/src/jepsen/mysql/build_smoke_test.clj
+++ b/src/jepsen/mysql/build_smoke_test.clj
@@ -1,0 +1,32 @@
+(ns jepsen.mysql.build-smoke-test
+  "A trivial workload that opens a connection and runs SELECT 1. Validates
+  that MariaDB starts and Jepsen can connect without risking analysis failures."
+  (:require [jepsen [checker :as checker]
+                    [client :as client]
+                    [generator :as gen]]
+            [jepsen.mysql [client :as c]]
+            [next.jdbc :as j]))
+
+(defrecord Client [conn]
+  client/Client
+  (open! [this test node]
+    (assoc this :conn (c/open test node)))
+
+  (setup! [_ _test])
+
+  (invoke! [_ _test op]
+    (let [result (j/execute-one! conn ["SELECT 1 AS v"])]
+      (assoc op :type :ok, :value (:v result))))
+
+  (teardown! [_ _test])
+
+  (close! [_ _test]
+    (c/close! conn)))
+
+(defn workload
+  [_opts]
+  {:generator (gen/limit 10 (repeat {:f :select-1, :value nil}))
+   :checker   (reify checker/Checker
+                (check [_ _ _ _]
+                  {:valid? true}))
+   :client    (Client. nil)})

--- a/src/jepsen/mysql/cli.clj
+++ b/src/jepsen/mysql/cli.clj
@@ -221,6 +221,27 @@
     :parse-fn keyword
     :missing  (str "Must specify a workload: " (cli/one-of workloads))
     :validate [workloads (cli/one-of workloads)]]
+
+   [nil "--dont-teardown" "Don't cleanup before and after testing."
+    :default false]
+
+   [nil "--rr PATH"
+    "Run mariadbd under rr, write rr trace to the directory in the option."
+    :default nil]
+
+   [nil "--mariadb-install-dir PATH" "The directory where mariadb is installed."
+    :default nil]
+
+   [nil "--mariadb-data-dir PATH" "Mariadb data dir."
+    :default nil]
+
+   [nil "--mariadb-tmp-dir PATH" "Mariadb tmp dir."
+    :default "/tmp"]
+
+   [nil "--mariadb-server-number NUMBER" "Mariadb server number."
+    :parse-fn parse-long
+    :default 0]
+
    ])
 
 (defn all-tests

--- a/src/jepsen/mysql/client.clj
+++ b/src/jepsen/mysql/client.clj
@@ -82,9 +82,11 @@
 (defn await-open
   "Waits for a connection to node to become available, returning conn. Helpful
   for starting up."
-  [test node]
+  ([test node]
+       (await-open test node {}))
+  ([test node opts]
   (util/await-fn (fn attempt []
-                   (let [conn (open test node)]
+                   (let [conn (open test node opts)]
                      (try (j/execute-one! conn
                                           ["create table if not exists jepsen_await (id int)"])
                           conn
@@ -93,7 +95,7 @@
                  {:retry-interval 1000
                   :log-interval   60000
                   :log-message    "Waiting for MySQL connection"
-                  :timeout        10000}))
+                  :timeout        10000})))
 
 (defmacro with-errors
   "Takes an operation and a body, turning known errors into :fail or :info ops."

--- a/src/jepsen/mysql/client.clj
+++ b/src/jepsen/mysql/client.clj
@@ -98,6 +98,11 @@
                   :log-message    "Waiting for MySQL connection"
                   :timeout        10000})))
 
+(defn query-id
+  "Constructs a SQL comment prefix from an operation's index and time."
+  [op]
+  (str "/* " (:index op) "_" (:time op) " */ "))
+
 (defmacro with-errors
   "Takes an operation and a body, turning known errors into :fail or :info ops."
   [op & body]

--- a/src/jepsen/mysql/closed_predicate.clj
+++ b/src/jepsen/mysql/closed_predicate.clj
@@ -149,9 +149,9 @@
             ; cluster and the DB automation isn't wiping the state for us.
             (j/execute! conn [(str "delete from " (table-name i))]))))))
 
-  (invoke! [this test {:keys [index time f value] :as op}]
+  (invoke! [this test {:keys [f value] :as op}]
     (let [[system value] value
-          query_id (str "/* " index "_" time " */ ")]
+          query_id (c/query-id op)]
       ; One-time connection setup
       (when (compare-and-set! initialized? false true)
         (c/set-transaction-isolation! conn (:isolation test)))

--- a/src/jepsen/mysql/db/maria_docker.clj
+++ b/src/jepsen/mysql/db/maria_docker.clj
@@ -1,0 +1,97 @@
+(ns jepsen.mysql.db.maria-docker
+  "Automates setting up and tearing down MariaDB."
+  (:require [clojure [pprint :refer [pprint]]
+                     [string :as str]]
+            [clojure.java.io :as io]
+            [clojure.tools.logging :refer [info warn]]
+            [jepsen [control :as c]
+                    [core :as jepsen]
+                    [db :as db]
+                    [util :as util :refer [meh]]]
+            [jepsen.control [net :as cn]
+                            [util :as cu]]
+            [jepsen.os.debian :as debian]
+            [jepsen.mysql [client :as mc]]
+            [jepsen.mysql.db.maria :as db.maria]
+            [next.jdbc :as j]
+            [next.jdbc.result-set :as rs]
+            [clojure.java.shell :as shell]
+            [org.httpkit.client :as http]
+            [slingshot.slingshot :refer [try+ throw+]]))
+
+(def home-dir "/home/mariadb")
+(def cnf-path (str home-dir "/.my.cnf"))
+(def install-dir (str home-dir "/mariadb-bin"))
+(def bin-dir (str install-dir "/bin"))
+(def scripts-dir (str install-dir "/scripts"))
+(def data-dir (str install-dir "/data"))
+(def error-log (str data-dir "/error.log"))
+
+(defn configure!
+  "Writes config files"
+  [test]
+  (spit cnf-path
+    (-> (io/resource "maria-docker.cnf")
+         slurp
+         (str/replace #"%PID_FILE%" (str data-dir "/mariadbd.pid"))
+         (str/replace #"%DATA_DIR%" data-dir)
+         (str/replace #"%ERROR_LOG%" error-log)
+         (str/replace #"%IP%" "127.0.0.1")
+         (str/replace #"%SERVER_ID%" "1")
+         (str/replace #"%REPLICA_PRESERVE_COMMIT_ORDER%" (:replica-preserve-commit-order test))
+         (str/replace #"%BINLOG_FORMAT%"
+                      (.toUpperCase (name (:binlog-format test))))
+         (str/replace #"%BINLOG_TRANSACTION_DEPENDENCY_TRACKING%"
+                      (case (:binlog-transaction-dependency-tracking test)
+                        :commit-order "COMMIT_ORDER"
+                        :writeset "WRITESET"
+                        :writeset-session "WRITESET_SESSION"))
+         ; This option doesn't exist in Maria AFAICT
+         (str/replace #"replica-preserve-commit-order.*?\n" "")
+         ; Followers are super-read-only to prevent updates from
+         ; accidentally arriving. Note that if we *don't* do this, mysql
+         ; will murder itself by trying to run replication transactions at
+         ; the same time as read queries and letting the read queries take
+         ; locks, breaking the replication update thread entirely? This
+         ; might be the worst system
+         ; I've ever worked on.
+         (str/replace #".*%SUPER_READ_ONLY%.*" "")
+         (str/replace #"%INNODB_FLUSH_LOG_AT_TRX_COMMIT%"
+                      (str (:innodb-flush-log-at-trx-commit test)))
+         )))
+
+(defn make-db!
+  "Adds a user and DB with remote access."
+  [test]
+  (let [c (mc/await-open test "localhost" {:db "mysql"})]
+    (j/execute! c [(str "CREATE DATABASE " mc/db)])
+    (if (:innodb-strict-isolation test)
+      (j/execute! c ["SET GLOBAL innodb_snapshot_isolation=ON"]))))
+
+(defn db
+  "A MySQL database. Takes CLI options."
+  [opts]
+  (let [; A promise which will receive the file and position of the leader node
+        repl-state (promise)]
+    (reify
+      db/DB
+      (setup! [this test node]
+        (configure! test)
+        (shell/sh (str scripts-dir "/mariadb-install-db"))
+        (db/start! this test node)
+        (make-db! test))
+
+      (teardown! [this test node]
+        (db/kill! this test node)
+        (shell/sh "rm" "-rf" data-dir)
+        (shell/sh "rm" cnf-path))
+
+      db/LogFiles
+      (log-files [this test node] [])
+
+      db/Kill
+      (start! [this test node]
+        (shell/sh (str bin-dir "/mariadbd-safe") "--no-auto-restart" "--skip-grant-tables"))
+
+      (kill! [this test node]
+        (shell/sh (str bin-dir "/mysqladmin") "-uroot" "shutdown" "--shutdown-timeout=3600")))))

--- a/src/jepsen/mysql/db/maria_docker.clj
+++ b/src/jepsen/mysql/db/maria_docker.clj
@@ -15,50 +15,91 @@
             [jepsen.mysql.db.maria :as db.maria]
             [next.jdbc :as j]
             [next.jdbc.result-set :as rs]
-            [clojure.java.shell :as shell]
+            [clojure.java.shell :refer [sh]]
             [org.httpkit.client :as http]
             [slingshot.slingshot :refer [try+ throw+]]))
 
-(def home-dir "/home/mariadb")
-(def cnf-path (str home-dir "/.my.cnf"))
-(def install-dir (str home-dir "/mariadb-bin"))
-(def bin-dir (str install-dir "/bin"))
-(def scripts-dir (str install-dir "/scripts"))
-(def data-dir (str install-dir "/data"))
-(def error-log (str data-dir "/error.log"))
+(def default-home-dir "/home/mariadb")
+(def default-cnf-path (str default-home-dir "/.my.cnf"))
+(def default-install-dir (str default-home-dir "/mariadb-bin"))
+(def default-data-dir (str default-install-dir "/data"))
+
+(defn cnf-path
+  "Mariadb config file path"
+  [test]
+  (let [opt-tmp-dir (:mariadb-tmp-dir test)
+        opt-server-num (:mariadb-server-number test)]
+    (str opt-tmp-dir "/my-" opt-server-num ".cnf")))
+
+(defn data-dir
+  "Mariadb data directory path"
+  [test]
+  (let [opt-data-dir (:mariadb-data-dir test)
+        opt-server-num (:mariadb-server-number test)]
+    (if (some? opt-data-dir)
+      (str opt-data-dir "-" opt-server-num) default-data-dir)))
+
+(defn pid-file
+  "MariaDB pid file"
+  [test]
+  (str (data-dir test) "/mariadbd.pid"))
+
+(defn install-dir
+  "MariaDB install dir"
+  [test]
+  (let [opt-install-dir (:mariadb-install-dir test)]
+    (if (some? opt-install-dir) opt-install-dir default-install-dir)))
+
+(defn socket
+  "MariaDB socket file"
+  [test]
+  (let [opt-server-num (:mariadb-server-number test)
+        opt-tmp-dir (:mariadb-tmp-dir test)]
+  (str opt-tmp-dir "/mariadb-" opt-server-num ".sock")))
 
 (defn configure!
   "Writes config files"
   [test]
-  (spit cnf-path
-    (-> (io/resource "maria-docker.cnf")
-         slurp
-         (str/replace #"%PID_FILE%" (str data-dir "/mariadbd.pid"))
-         (str/replace #"%DATA_DIR%" data-dir)
-         (str/replace #"%ERROR_LOG%" error-log)
-         (str/replace #"%IP%" "127.0.0.1")
-         (str/replace #"%SERVER_ID%" "1")
-         (str/replace #"%REPLICA_PRESERVE_COMMIT_ORDER%" (:replica-preserve-commit-order test))
-         (str/replace #"%BINLOG_FORMAT%"
-                      (.toUpperCase (name (:binlog-format test))))
-         (str/replace #"%BINLOG_TRANSACTION_DEPENDENCY_TRACKING%"
-                      (case (:binlog-transaction-dependency-tracking test)
-                        :commit-order "COMMIT_ORDER"
-                        :writeset "WRITESET"
-                        :writeset-session "WRITESET_SESSION"))
-         ; This option doesn't exist in Maria AFAICT
-         (str/replace #"replica-preserve-commit-order.*?\n" "")
-         ; Followers are super-read-only to prevent updates from
-         ; accidentally arriving. Note that if we *don't* do this, mysql
-         ; will murder itself by trying to run replication transactions at
-         ; the same time as read queries and letting the read queries take
-         ; locks, breaking the replication update thread entirely? This
-         ; might be the worst system
-         ; I've ever worked on.
-         (str/replace #".*%SUPER_READ_ONLY%.*" "")
-         (str/replace #"%INNODB_FLUSH_LOG_AT_TRX_COMMIT%"
-                      (str (:innodb-flush-log-at-trx-commit test)))
-         )))
+  (let [opt-cnf-path (cnf-path test)
+        opt-data-dir (data-dir test)
+        opt-error-log (str opt-data-dir "/error.log")
+        opt-pid-file (pid-file test)
+        opt-server-num (:mariadb-server-number test)
+        opt-tmp-dir (:mariadb-tmp-dir test) 
+        port (str (+ 3306 opt-server-num))
+        opt-socket (socket test)]
+    (spit opt-cnf-path
+      (-> (io/resource "maria-docker.cnf")
+           slurp
+           (str/replace #"%TMPDIR%" opt-tmp-dir)
+           (str/replace #"%PORT%" port)
+           (str/replace #"%SOCKET%" opt-socket)
+           (str/replace #"%PID_FILE%" opt-pid-file)
+           (str/replace #"%DATA_DIR%" opt-data-dir)
+           (str/replace #"%ERROR_LOG%" opt-error-log)
+           (str/replace #"%IP%" "127.0.0.1")
+           (str/replace #"%SERVER_ID%" "1")
+           (str/replace #"%REPLICA_PRESERVE_COMMIT_ORDER%" (:replica-preserve-commit-order test))
+           (str/replace #"%BINLOG_FORMAT%"
+                        (.toUpperCase (name (:binlog-format test))))
+           (str/replace #"%BINLOG_TRANSACTION_DEPENDENCY_TRACKING%"
+                        (case (:binlog-transaction-dependency-tracking test)
+                          :commit-order "COMMIT_ORDER"
+                          :writeset "WRITESET"
+                          :writeset-session "WRITESET_SESSION"))
+           ; This option doesn't exist in Maria AFAICT
+           (str/replace #"replica-preserve-commit-order.*?\n" "")
+           ; Followers are super-read-only to prevent updates from
+           ; accidentally arriving. Note that if we *don't* do this, mysql
+           ; will murder itself by trying to run replication transactions at
+           ; the same time as read queries and letting the read queries take
+           ; locks, breaking the replication update thread entirely? This
+           ; might be the worst system
+           ; I've ever worked on.
+           (str/replace #".*%SUPER_READ_ONLY%.*" "")
+           (str/replace #"%INNODB_FLUSH_LOG_AT_TRX_COMMIT%"
+                        (str (:innodb-flush-log-at-trx-commit test)))
+           ))))
 
 (defn make-db!
   "Adds a user and DB with remote access."
@@ -77,21 +118,53 @@
       db/DB
       (setup! [this test node]
         (configure! test)
-        (shell/sh (str scripts-dir "/mariadb-install-db"))
+        (sh (str (install-dir test) "/scripts/mariadb-install-db")
+            (str "--defaults-file=" (cnf-path test)))
         (db/start! this test node)
         (make-db! test))
 
       (teardown! [this test node]
-        (db/kill! this test node)
-        (shell/sh "rm" "-rf" data-dir)
-        (shell/sh "rm" cnf-path))
+        (if-not (:dont-teardown test)
+          ((db/kill! this test node)
+           (sh "rm" "-rf" (data-dir test))
+           (sh "rm" (cnf-path test)))))
 
       db/LogFiles
       (log-files [this test node] [])
 
       db/Kill
       (start! [this test node]
-        (shell/sh (str bin-dir "/mariadbd-safe") "--no-auto-restart" "--skip-grant-tables"))
+        (let [opt-cnf-path (cnf-path test)
+              opt-install-dir (install-dir test)
+              bin-dir (str opt-install-dir "/bin")
+              rr-trace-dir (:rr test)]
+           (if (some? rr-trace-dir)
+             (future (sh "rr" "record"
+                      (str bin-dir "/mariadbd")
+                      (str "--defaults-file=" opt-cnf-path)
+                      (str "--basedir=" opt-install-dir)
+                      (str "--plugin-dir=" opt-install-dir "/lib/plugin")
+                      "--skip-grant-tables"
+                      :env {:_RR_TRACE_DIR rr-trace-dir}))
+             (sh (str bin-dir "/mariadbd-safe")
+                 (str "--defaults-file=" opt-cnf-path)
+                 "--no-auto-restart" "--skip-grant-tables"))
+           (while
+             (not= (:exit
+                     (sh (str bin-dir "/mysqladmin")
+                         (str "--defaults-file=" opt-cnf-path)
+                         (str "--socket=" (socket test))
+                         "-uroot" "ping"))
+                   0)
+               (info "Waiting for mariadbd start...")
+               (Thread/sleep 1000))
+           (info "mariadbd started")))
 
       (kill! [this test node]
-        (shell/sh (str bin-dir "/mysqladmin") "-uroot" "shutdown" "--shutdown-timeout=3600")))))
+        (let [opt-cnf-path (cnf-path test)
+              opt-install-dir (install-dir test)
+              bin-dir (str opt-install-dir "/bin")]
+        (sh (str bin-dir "/mysqladmin")
+            (str "--defaults-file=" opt-cnf-path)
+            (str "--socket=" (socket test))
+            "-uroot" "shutdown" "--shutdown-timeout=3600"))))))

--- a/src/jepsen/mysql/db/maria_docker.clj
+++ b/src/jepsen/mysql/db/maria_docker.clj
@@ -1,23 +1,12 @@
 (ns jepsen.mysql.db.maria-docker
   "Automates setting up and tearing down MariaDB."
-  (:require [clojure [pprint :refer [pprint]]
-                     [string :as str]]
+  (:require [clojure [string :as str]]
             [clojure.java.io :as io]
             [clojure.tools.logging :refer [info warn]]
-            [jepsen [control :as c]
-                    [core :as jepsen]
-                    [db :as db]
-                    [util :as util :refer [meh]]]
-            [jepsen.control [net :as cn]
-                            [util :as cu]]
-            [jepsen.os.debian :as debian]
+            [jepsen [db :as db]]
             [jepsen.mysql [client :as mc]]
-            [jepsen.mysql.db.maria :as db.maria]
             [next.jdbc :as j]
-            [next.jdbc.result-set :as rs]
-            [clojure.java.shell :refer [sh]]
-            [org.httpkit.client :as http]
-            [slingshot.slingshot :refer [try+ throw+]]))
+            [clojure.java.shell :refer [sh]]))
 
 (def default-home-dir "/home/mariadb")
 (def default-cnf-path (str default-home-dir "/.my.cnf"))
@@ -106,15 +95,13 @@
   [test]
   (let [c (mc/await-open test "localhost" {:db "mysql"})]
     (j/execute! c [(str "CREATE DATABASE " mc/db)])
-    (if (:innodb-strict-isolation test)
+    (if (:innodb-snapshot-isolation test)
       (j/execute! c ["SET GLOBAL innodb_snapshot_isolation=ON"]))))
 
 (defn db
   "A MySQL database. Takes CLI options."
   [opts]
-  (let [; A promise which will receive the file and position of the leader node
-        repl-state (promise)]
-    (reify
+  (reify
       db/DB
       (setup! [this test node]
         (configure! test)
@@ -124,10 +111,10 @@
         (make-db! test))
 
       (teardown! [this test node]
-        (if-not (:dont-teardown test)
-          ((db/kill! this test node)
-           (sh "rm" "-rf" (data-dir test))
-           (sh "rm" (cnf-path test)))))
+        (when-not (:dont-teardown test)
+          (db/kill! this test node)
+          (sh "rm" "-rf" (data-dir test))
+          (sh "rm" (cnf-path test))))
 
       db/LogFiles
       (log-files [this test node] [])
@@ -167,4 +154,4 @@
         (sh (str bin-dir "/mysqladmin")
             (str "--defaults-file=" opt-cnf-path)
             (str "--socket=" (socket test))
-            "-uroot" "shutdown" "--shutdown-timeout=3600"))))))
+            "-uroot" "shutdown" "--shutdown-timeout=3600")))))

--- a/src/jepsen/mysql/mav.clj
+++ b/src/jepsen/mysql/mav.clj
@@ -49,8 +49,8 @@
           (j/execute! conn ["insert into mav (id, `value`, noop) values (?, ?, ?)" 0 0 0])
           (j/execute! conn ["insert into mav (id, `value`, noop) values (?, ?, ?)" 1 0 0])))))
 
-  (invoke! [this test {:keys [index time f value] :as op}]
-    (let [query_id (str "/* " index "_" time " */ ")]
+  (invoke! [this test {:keys [f value] :as op}]
+    (let [query_id (c/query-id op)]
       (case f
         :write
         (j/with-transaction [t conn {:isolation (:isolation test)}]

--- a/src/jepsen/mysql/nonrepeatable_read.clj
+++ b/src/jepsen/mysql/nonrepeatable_read.clj
@@ -53,8 +53,8 @@
           (j/execute! conn ["insert into people (id, name, gender) values (?, ?, ?)"
                             0 "moss" "enby"])))))
 
-  (invoke! [this test {:keys [index time f value] :as op}]
-    (let [query_id (str "/* " index "_" time " */ ")]
+  (invoke! [this test {:keys [f value] :as op}]
+    (let [query_id (c/query-id op)]
       (case f
         :change-name (do (j/execute!
                            conn [(str query_id "update people set name = ? where id = ?")


### PR DESCRIPTION
## Summary

- Merge upstream `jepsen-io/mysql` changes (Antithesis support, Galera replication, dependency bumps, bug fixes)
- Rename artifact from `jepsen.mysql` to `jepsen.mariadb`
- Bump deps: next.jdbc 1.3.1093, mysql-connector-j 9.7.0, mariadb-java-client 3.5.8
- Dockerfile: Ubuntu 24.04, collapsed layers, immutable image
- Rewrite `start.sh`: three run modes (clone+build, prebuilt install, build tree shim)
- Split test scripts: `start.sh` (setup), `tests.sh` (full suite), `verify.sh` (build smoke test)
- Add `build-smoke-test` workload: `SELECT 1` through Jepsen for CI verification
- Add GHA CI workflow: `lein check` + Maven deploy to GitHub Packages
- Add GHA Docker workflow: build, smoke test, publish to GHCR with release automation
- Fix bugs: wipe keyword mismatch, teardown nil-as-function, unused imports
- Extract shared `query-id` helper to client namespace

## Test plan

- [ ] CI `lein check` passes
- [ ] Docker image builds successfully
- [ ] `build-smoke-test` workload runs through Jepsen and exits 0
- [ ] Full test suite (`tests.sh`) runs against MariaDB 10.11